### PR TITLE
improve error handling in opening shaders

### DIFF
--- a/src/engine/Shader.cpp
+++ b/src/engine/Shader.cpp
@@ -32,9 +32,22 @@ namespace lei3d
 			vertexCode = vShaderStream.str();
 			fragmentCode = fShaderStream.str();
 		}
-		catch (std::ifstream::failure* e)
+		catch (const std::ifstream::failure& e)
 		{
-			LEI_ERROR("ERROR - Shader File Not Successfully Read");
+			if (vShaderFile.fail())
+			{
+				LEI_ERROR("ERROR - Failed to open vertex shader file: " + std::string(vertexShaderPath));
+			}
+			else if (fShaderFile.fail())
+			{
+				LEI_ERROR("ERROR - Failed to open fragment shader file: " + std::string(fragShaderPath));
+			}
+			else
+			{
+				// in my experience this outputs something like "basic_ios::clear: iostream error"
+				// for something like a file not found. preferably the specific error would be output
+				LEI_ERROR("ERROR - Shader File Not Successfully Read: " + std::string(e.what()));
+			}
 		}
 		const char* vShaderCode = vertexCode.c_str(); // yeah I can work with c strings ( ͡° ͜ʖ ͡°)
 		const char* fShaderCode = fragmentCode.c_str();


### PR DESCRIPTION
This is pretty much just making the error handling when not being able to open a file in Shader.cpp, actually work. Here's what the program currently does when not being able to load a shader:
```cpp
Initializing Engine
Loading Resources
terminate called after throwing an instance of 'std::__ios_failure'
  what():  basic_ios::clear: iostream error
```
The root cause behind this was the file not being found, because every time it tries to load anything from `data` it's from the current working directory, rather than the absolute directory of where the binary is running from. Pretty much any of these will fail in that circumstance:
```cpp
../src/engine/SkyBox.cpp:        skyboxShader = Shader("./data/shaders/skybox.vert", "./data/shaders/skybox.frag");
../src/engine/PCGHelpers.cpp:        unsigned char* data = stbi_load("./data/textures/elevation.png", &width, &height, &nrChannels, 0);
../src/engine/Engine.cpp:	// this makes it so that data/ and other directories load when the cwd is wrong
../src/engine/Engine.cpp:        shader = Shader("./data/shaders/transformations.vert", "./data/shaders/transformations.frag");
../src/engine/Engine.cpp:        std::string path = "data/models/backpack/backpack.obj";
../src/engine/Engine.cpp:            "data/skybox/anime_etheria/right.jpg",
../src/engine/Engine.cpp:            "data/skybox/anime_etheria/left.jpg",
../src/engine/Engine.cpp:            "data/skybox/anime_etheria/up.jpg",
../src/engine/Engine.cpp:            "data/skybox/anime_etheria/down.jpg",
../src/engine/Engine.cpp:            "data/skybox/anime_etheria/front.jpg",
../src/engine/Engine.cpp:            "data/skybox/anime_etheria/back.jpg"
```
One of two things could resolve the root cause, either define the data directory as a constant or set the working directory to the directory the binary is running out of. However, since there isn't a cross-platform way to do this, I've left this either to the imagination or to never be resolved. The iostream exception from earlier actually stops the whole program from loading, but with this new error handling it continues to load just without the shaders - might make things worse.

(Pretty much all of the above has already been discussed in the Discord)
That's all I have to say about this, merge it or don't, it SHOULDN'T cause issues on Windows??