### PR TITLE
modified all include imports to remove extra include in path

### DIFF
--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -1,8 +1,8 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
-#include "include/engine/Engine.hpp"
-#include "include/util/GLDebug.hpp"
+#include "engine/Engine.hpp"
+#include "util/GLDebug.hpp"
 
 namespace lei3d
 {

--- a/src/engine/Entity.cpp
+++ b/src/engine/Entity.cpp
@@ -1,4 +1,4 @@
-#include "include/engine/Entity.hpp"
+#include "engine/Entity.hpp"
 
 namespace lei3d
 {

--- a/src/engine/FlyCamera.cpp
+++ b/src/engine/FlyCamera.cpp
@@ -1,4 +1,4 @@
-#include "include/engine/FlyCamera.hpp"
+#include "engine/FlyCamera.hpp"
 
 namespace lei3d
 {

--- a/src/engine/GLDebug.cpp
+++ b/src/engine/GLDebug.cpp
@@ -1,4 +1,4 @@
-#include "include/util/GLDebug.hpp"
+#include "util/GLDebug.hpp"
 #include <glad/glad.h>
 
 #include <sstream>

--- a/src/engine/Log.cpp
+++ b/src/engine/Log.cpp
@@ -1,4 +1,4 @@
-#include "include/util/Log.hpp"
+#include "util/Log.hpp"
 
 #include "spdlog/sinks/stdout_color_sinks.h"
 

--- a/src/engine/Mesh.cpp
+++ b/src/engine/Mesh.cpp
@@ -1,4 +1,4 @@
-#include "include/engine/Mesh.hpp"
+#include "engine/Mesh.hpp"
 
 namespace lei3d
 {

--- a/src/engine/Model.cpp
+++ b/src/engine/Model.cpp
@@ -1,4 +1,4 @@
-#include "include/engine/Model.hpp"
+#include "engine/Model.hpp"
 
 namespace lei3d
 {

--- a/src/engine/PCGHelpers.cpp
+++ b/src/engine/PCGHelpers.cpp
@@ -1,4 +1,4 @@
-#include "include/pcg/PCGHelpers.hpp"
+#include "pcg/PCGHelpers.hpp"
 
 namespace lei3d 
 {

--- a/src/engine/Physics.cpp
+++ b/src/engine/Physics.cpp
@@ -1,4 +1,4 @@
-#include "include/physics/Physics.hpp"
+#include "physics/Physics.hpp"
 
 namespace lei3d
 {

--- a/src/engine/Shader.cpp
+++ b/src/engine/Shader.cpp
@@ -1,5 +1,5 @@
-﻿#include "include/engine/Shader.hpp"
-#include "include/util/GLDebug.hpp"
+﻿#include "engine/Shader.hpp"
+#include "util/GLDebug.hpp"
 
 namespace lei3d 
 {

--- a/src/engine/SkyBox.cpp
+++ b/src/engine/SkyBox.cpp
@@ -1,6 +1,6 @@
-#include "include/engine/SkyBox.hpp"
+#include "engine/SkyBox.hpp"
 
-#include "include/util/GLDebug.hpp"
+#include "util/GLDebug.hpp"
 
 namespace lei3d
 {

--- a/src/engine/include/engine/Engine.hpp
+++ b/src/engine/include/engine/Engine.hpp
@@ -11,13 +11,13 @@
 #include <vector>
 #include <filesystem>
 
-#include "include/engine/Shader.hpp"
-#include "include/pcg/PCGHelpers.hpp"
-#include "include/engine/FlyCamera.hpp"
-#include "include/engine/Model.hpp"
-#include "include/engine/SkyBox.hpp"
-#include "include/engine/Entity.hpp"
-#include "include/physics/Physics.hpp"
+#include "engine/Shader.hpp"
+#include "pcg/PCGHelpers.hpp"
+#include "engine/FlyCamera.hpp"
+#include "engine/Model.hpp"
+#include "engine/SkyBox.hpp"
+#include "engine/Entity.hpp"
+#include "physics/Physics.hpp"
 
 namespace lei3d
 {

--- a/src/engine/include/engine/Entity.hpp
+++ b/src/engine/include/engine/Entity.hpp
@@ -5,7 +5,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
-#include "include/engine/Model.hpp"
+#include "engine/Model.hpp"
 
 namespace lei3d
 {

--- a/src/engine/include/engine/Mesh.hpp
+++ b/src/engine/include/engine/Mesh.hpp
@@ -6,7 +6,7 @@
 
 #include <glm/glm.hpp>
 
-#include "include/engine/Shader.hpp"
+#include "engine/Shader.hpp"
 
 namespace lei3d
 {

--- a/src/engine/include/engine/Model.hpp
+++ b/src/engine/include/engine/Model.hpp
@@ -12,8 +12,8 @@
 #include <stb_image.h>
 #endif
 
-#include "include/engine/Shader.hpp"
-#include "include/engine/Mesh.hpp"
+#include "engine/Shader.hpp"
+#include "engine/Mesh.hpp"
 
 namespace lei3d
 {

--- a/src/engine/include/engine/SkyBox.hpp
+++ b/src/engine/include/engine/SkyBox.hpp
@@ -10,7 +10,7 @@
 #include <stb_image.h>
 #endif
 
-#include "include/engine/Shader.hpp"
+#include "engine/Shader.hpp"
 
 namespace lei3d
 {

--- a/src/engine/include/util/GLDebug.hpp
+++ b/src/engine/include/util/GLDebug.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "include/util/Log.hpp"
+#include "util/Log.hpp"
 
 #define GLCall(x) GLClearError();\
 	x;\

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -4,8 +4,8 @@
  * Author: Kevin Sadi
  */
 
-#include "include/engine/Engine.hpp"
-#include "include/util/Log.hpp"
+#include "engine/Engine.hpp"
+#include "util/Log.hpp"
 
 using namespace lei3d;
 


### PR DESCRIPTION
After discussion, we have found that the cmake file tries to find include files in `src/engine/include`, thus the `includes/` in the #include filepaths was not necessary. This was also causing issues when it came to compilation on Linux. This might be a fix the Linux compilation error.  