### PR TITLE
Changes to project that allow compatibility for gcc 13.2.1 on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ build-linux/
 buildtest/
 .vscode/
 .vs/
+cmake-build-debug/
+.idea/
 
 # `git rm --cached -r .`  to remove files added to a git commit but in the .gitignore

--- a/src/engine/core/Application.cpp
+++ b/src/engine/core/Application.cpp
@@ -206,7 +206,7 @@ namespace lei3d
 		ImGui::EndFrame();
 	}
 
-	PrimitiveRenderer& Application::PrimitiveRenderer()
+	PrimitiveRenderer& Application::GetPrimitiveRenderer()
 	{
 		return s_Instance->m_PrimitiveRenderer;
 	}

--- a/src/engine/core/Application.hpp
+++ b/src/engine/core/Application.hpp
@@ -60,7 +60,7 @@ namespace lei3d
 
 		static GLFWwindow* Window();
 		static float	   DeltaTime();
-		static PrimitiveRenderer& PrimitiveRenderer();
+		static PrimitiveRenderer& GetPrimitiveRenderer();
 
 	private:
 		void Initialize(); // Start the App

--- a/src/engine/physics/LeiDebugDrawer.cpp
+++ b/src/engine/physics/LeiDebugDrawer.cpp
@@ -8,7 +8,7 @@ namespace lei3d
 {
 	void LeiDebugDrawer::drawLine(const btVector3& from, const btVector3& to, const btVector3& color)
 	{
-		Application::PrimitiveRenderer().pushLine(SceneManager::ActiveScene().MainCamera(), btToGLMVec3(from), btToGLMVec3(to), btToGLMVec3(color), 0.5f);
+		Application::GetPrimitiveRenderer().pushLine(SceneManager::ActiveScene().MainCamera(), btToGLMVec3(from), btToGLMVec3(to), btToGLMVec3(color), 0.5f);
 	}
 
 	int LeiDebugDrawer::getDebugMode() const

--- a/src/engine/rendering/Material.hpp
+++ b/src/engine/rendering/Material.hpp
@@ -2,6 +2,7 @@
 
 #include <glm/glm.hpp>
 #include <rendering/Shader.hpp>
+#include <memory>
 
 namespace lei3d
 {

--- a/src/engine/rendering/PrimitiveRenderer.cpp
+++ b/src/engine/rendering/PrimitiveRenderer.cpp
@@ -44,7 +44,7 @@ namespace lei3d
 		data.u_Color = color;
 		;
 		VertexBufferLayout vbLayout;
-		vbLayout.push<float>(3);
+		vbLayout.push(3, GL_FLOAT);
 		data.m_VAO->addBuffer(*data.m_VBO, vbLayout);
 
 		m_DrawCalls.push(std::move(data));

--- a/src/engine/rendering/buffers/VertexBufferLayout.hpp
+++ b/src/engine/rendering/buffers/VertexBufferLayout.hpp
@@ -42,32 +42,13 @@ public:
 		: m_Stride(0) {}
 
 	// Allocates space for an attribute in the layout with the number of components specified.
-	template <typename T>
-	void push(unsigned int count)
-	{
-	}
-
-	template <>
-	void push<float>(unsigned int count)
+	void push(unsigned int count, unsigned int type)
 	{
 		m_Attributes.push_back({ GL_FLOAT, count, GL_FALSE });
-		m_Stride += count * VertexBufferAttribute::getSizeOfType(GL_FLOAT);
-	}
-
-	template <>
-	void push<unsigned int>(unsigned int count)
-	{
-		m_Attributes.push_back({ GL_UNSIGNED_INT, count, GL_FALSE });
-		m_Stride += count * VertexBufferAttribute::getSizeOfType(GL_UNSIGNED_INT);
-	}
-
-	template <>
-	void push<unsigned char>(unsigned int count)
-	{
-		m_Attributes.push_back({ GL_UNSIGNED_BYTE, count, GL_TRUE });
-		m_Stride += count * VertexBufferAttribute::getSizeOfType(GL_UNSIGNED_BYTE);
+		m_Stride += count * VertexBufferAttribute::getSizeOfType(type);
 	}
 
 	inline const std::vector<VertexBufferAttribute> getElements() const { return m_Attributes; };
 	inline unsigned int								getStride() const { return m_Stride; };
 };
+


### PR DESCRIPTION
Removed template specialization in favor of passing openGL type as a parameter, refactored getter function from PrimitiveRenderer to GetPrimitiveRenderer, included <memory> module in Material.hpp