### PR TITLE
Fixed glad.h not found while compiling

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -14,6 +14,9 @@ add_library(lei3d_lib
         ${ENGINE_SOURCE}
         )
 
+add_dependencies (lei3d_lib glad)
+
+
 target_include_directories(lei3d_lib PUBLIC
         .
         ${GLFW_INCLUDE}


### PR DESCRIPTION
Issue was that `CharacterController.o` was being built before `glad` was. The fix was to add `glad` as a dependency to the `engine` module