### PR TITLE
allowed changing entity positions in gui

### DIFF
--- a/src/engine/components/CharacterController.cpp
+++ b/src/engine/components/CharacterController.cpp
@@ -87,9 +87,16 @@ namespace lei3d
 	void CharacterController::PhysicsUpdate()
 	{
 		btTransform characterTrans;
-		m_MotionState->getWorldTransform(characterTrans);
+		// if entity pos changed
+		if (m_Entity.m_ResetTransform) {
+			m_Entity.m_ResetTransform = false;
+			characterTrans = m_Entity.getBTTransform();
+			m_RigidBody->setWorldTransform(characterTrans);
+			m_MotionState->setWorldTransform(characterTrans);
+		} else {
+			m_MotionState->getWorldTransform(characterTrans);
+		}
 		m_GroundCheckObj->setWorldTransform(getGroundCheckTransform(characterTrans));
-
 		m_Entity.setFromBTTransform(characterTrans);
 	}
 

--- a/src/engine/components/StaticCollider.cpp
+++ b/src/engine/components/StaticCollider.cpp
@@ -70,4 +70,17 @@ namespace lei3d
 		world.m_dynamicsWorld->addRigidBody(m_RigidBody);
 	}
 
+	// FOR SOME REASON THE COLLISION MESH DOESN'T CHANGE
+	void StaticCollider::PhysicsUpdate()
+	{
+		btTransform trans;
+		// if entity pos changed
+		if (m_Entity.m_ResetTransform) {
+			m_Entity.m_ResetTransform = false;
+			trans = m_Entity.getBTTransform();
+			m_RigidBody->setWorldTransform(trans);
+			m_MotionState->setWorldTransform(trans);
+			m_Entity.setFromBTTransform(trans);
+		}
+	}
 } // namespace lei3d

--- a/src/engine/components/StaticCollider.hpp
+++ b/src/engine/components/StaticCollider.hpp
@@ -22,6 +22,7 @@ namespace lei3d
 
 		void Init();
 		void SetColliderToModel(Model& model);
+		void PhysicsUpdate() override;
 
 	private:
 		void AddCollisionsFromTriangleMesh(btTriangleMesh* triMesh, const Transform& transform);

--- a/src/engine/core/Entity.cpp
+++ b/src/engine/core/Entity.cpp
@@ -176,10 +176,9 @@ namespace lei3d
 			constexpr float STEP_FINE = 0.5f;
 			constexpr float STEP_FAST = 10.0f; // Hold down Ctrl to scroll faster.
 
-			ImGui::InputFloat("x", &x, STEP_FINE, STEP_FAST);
-			// ImGui::SameLine();
-			ImGui::InputFloat("y", &y, STEP_FINE, STEP_FAST);
-			// ImGui::SameLine();
+			m_ResetTransform = 
+			ImGui::InputFloat("x", &x, STEP_FINE, STEP_FAST) |
+			ImGui::InputFloat("y", &y, STEP_FINE, STEP_FAST) |
 			ImGui::InputFloat("z", &z, STEP_FINE, STEP_FAST);
 
 			// NOTE: If the position is not changing, it's probably because the physics engine (or something else) is overwriting it)

--- a/src/engine/core/Entity.hpp
+++ b/src/engine/core/Entity.hpp
@@ -34,6 +34,7 @@ namespace lei3d
 
 	public:
 		Transform m_Transform;
+		bool m_ResetTransform;
 
 		Entity();
 		Entity(const std::string& name);


### PR DESCRIPTION
fixed by setting a flag to reset the physics rigid body transforms upon editing gui entries. still doesn't work for the physics playground/static collider for some reason, might need more looking into