### PR TITLE
Implements cascaded shadow maps (CSM)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,8 @@ BasedOnStyle: LLVM
 
 AccessModifierOffset: -4
 AlignAfterOpenBracket: DontAlign
-AlignConsecutiveDeclarations: true
+AlignConsecutiveMacros: Consecutive
+AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
 AlignOperands: DontAlign
 AlignTrailingComments: true
@@ -42,6 +43,6 @@ IndentPPDirectives: BeforeHash
 IndentWidth: 4
 NamespaceIndentation: All
 PointerAlignment: Left
-SortIncludes: false
+SortIncludes: Never
 TabWidth: 4
 UseTab: Always

--- a/data/shaders/depth_cascades.geom
+++ b/data/shaders/depth_cascades.geom
@@ -1,0 +1,18 @@
+#version 410 core
+layout (triangles, invocations = 5) in;
+layout (triangle_strip, max_vertices = 3) out;
+
+//layout (std140) uniform LightSpaceMatrices {
+//    mat4 lightSpaceMatrices[4];
+//};
+
+uniform mat4 lightSpaceMatrices[4];
+
+void main() {
+    for (int i = 0; i < 3; i++) {
+        gl_Position = lightSpaceMatrices[gl_InvocationID] * gl_in[i].gl_Position;
+        gl_Layer = gl_InvocationID;
+        EmitVertex();
+    }
+    EndPrimitive();
+}

--- a/data/shaders/forward.frag
+++ b/data/shaders/forward.frag
@@ -33,15 +33,19 @@ struct DirLight {
     vec3 color;
     float intensity;
 
-    float nearPlane;
     float farPlane;
+    float cascadeDistances[3];
 };
+
+//layout (std140) uniform LightSpaceMatrices {
+//    mat4 lightSpaceMatrices[4];
+//};
 
 in vec3 FragPos;
 in vec3 Normal;
 in vec2 TexCoords;
+in mat4 camView;
 in mat3 TBN;
-in vec4 FragPos_lS;
 
 layout (location = 0) out vec3 FragOut;
 layout (location = 1) out vec3 SaturationOut;
@@ -49,7 +53,8 @@ layout (location = 1) out vec3 SaturationOut;
 uniform Material material;
 uniform DirLight dirLight;
 uniform vec3 camPos;
-uniform sampler2D shadowDepth;
+uniform sampler2DArray shadowDepth;
+uniform mat4 lightSpaceMatrices[4];
 
 const float PI = 3.14159265359;
 const float PositiveExponent = 40.0;
@@ -105,22 +110,33 @@ vec3 srgb_to_linear(vec3 color) {
 }
 
 float calcShadowPCF(vec3 normal) {
-    vec3 coords = FragPos_lS.xyz / FragPos_lS.w;
+    vec4 fragPos_vS = camView * vec4(FragPos, 1.0);
+    float depth = abs(fragPos_vS.z);
+
+    vec4 res = step(depth, vec4(dirLight.cascadeDistances[0], dirLight.cascadeDistances[1], dirLight.cascadeDistances[2], dirLight.farPlane));
+    int layer = 4 - int(res.x + res.y + res.z + res.w);
+    vec4 fragPos_lS = lightSpaceMatrices[layer] * vec4(FragPos, 1.0);
+
+    vec3 coords = fragPos_lS.xyz / fragPos_lS.w;
     coords = coords * 0.5 + 0.5;
 
     float bias = max(0.05 * (1.0 - dot(normal, -dirLight.direction)), 0.005);
-    float closestDepth = texture(shadowDepth, coords.xy).x;
+    if (layer == 4) {
+        bias *= 1.0 / dirLight.farPlane * 0.5;
+    } else {
+        bias *= 1.0 / (dirLight.cascadeDistances[layer] * 0.5);
+    }
     float currDepth = coords.z;
 
     float shadow = 0.0;
     if (!(currDepth > 1.0)) {
         vec2 texelSize = vec2(1.0);
-        texelSize /= textureSize(shadowDepth, 0);
+        texelSize /= vec2(textureSize(shadowDepth, 0));
 
         // PCF
         for (int i = 0; i < NUM_PCF_SAMPLES; i++) {
             float pcfDepth = 1.0;
-            pcfDepth = texture(shadowDepth, coords.xy + Poisson[i] * texelSize).r;
+            pcfDepth = texture(shadowDepth, vec3(coords.xy + Poisson[i] * texelSize, layer)).r;
             shadow += currDepth - bias > pcfDepth ? 1.0 : 0.0;
         }
         shadow /= float(NUM_PCF_SAMPLES);

--- a/data/shaders/forward.vert
+++ b/data/shaders/forward.vert
@@ -8,20 +8,20 @@ layout (location = 3) in vec3 aTangent;
 out vec3 FragPos;
 out vec3 Normal;
 out vec2 TexCoords;
+out mat4 camView;
 out mat3 TBN;
-out vec4 FragPos_lS;
 
 uniform mat4 model;
 uniform mat4 view;
 uniform mat4 projection;
-uniform mat4 lightSpaceMatrix;
 
 void main() {
     gl_Position = projection * view * model * vec4(aPos, 1.0);
     FragPos = vec3(model * vec4(aPos, 1.0));
     Normal = vec3(mat4(mat3(model)) * vec4(aNormal, 1.0));
     TexCoords = aTexCoords;
-    FragPos_lS = lightSpaceMatrix * vec4(FragPos, 1.0);
+
+    camView = view;
 
     vec3 T = normalize(vec3(model * vec4(aTangent, 0.0)));
     vec3 N = normalize(vec3(model * vec4(aNormal, 0.0)));

--- a/data/shaders/null.frag
+++ b/data/shaders/null.frag
@@ -1,0 +1,5 @@
+#version 330 core
+
+void main() {
+    // empty
+}

--- a/data/shaders/shadow_depth.vert
+++ b/data/shaders/shadow_depth.vert
@@ -1,12 +1,9 @@
 #version 330 core
 layout (location = 0) in vec3 aPos;
 
-out vec3 FragPos;
-
 uniform mat4 lightSpaceMatrix;
 uniform mat4 model;
 
 void main() {
     gl_Position = lightSpaceMatrix * model * vec4(aPos, 1.0);
-    FragPos = vec3(model * vec4(aPos, 1.0));
 }

--- a/data/shaders/shadow_depth.vert
+++ b/data/shaders/shadow_depth.vert
@@ -1,9 +1,8 @@
 #version 330 core
 layout (location = 0) in vec3 aPos;
 
-uniform mat4 lightSpaceMatrix;
 uniform mat4 model;
 
 void main() {
-    gl_Position = lightSpaceMatrix * model * vec4(aPos, 1.0);
+    gl_Position = model * vec4(aPos, 1.0);
 }

--- a/src/engine/components/Lights.cpp
+++ b/src/engine/components/Lights.cpp
@@ -1,5 +1,21 @@
 #include "Lights.hpp"
 
+#include "core/Application.hpp"
+#include "logging/GLDebug.hpp"
+
 namespace lei3d
 {
+	DirectionalLight::DirectionalLight(glm::vec3 dir, glm::vec3 col, float intensity)
+		: direction(glm::normalize(dir)), color(col), intensity(intensity)
+	{
+		Camera& camera = Application::GetSceneCamera();
+		float farZ = camera.GetFarPlane();
+		cascadeLevels = std::vector<float>{ farZ * 0.067f, farZ * 0.2f, farZ * 0.5f };
+
+//		GLCall(glGenBuffers(1, &lsmUBO));
+//		GLCall(glBindBuffer(GL_UNIFORM_BUFFER, lsmUBO));
+//		GLCall(glBufferData(GL_UNIFORM_BUFFER, sizeof(glm::mat4x4) * 4, nullptr, GL_STATIC_DRAW));
+//		GLCall(glBindBufferBase(GL_UNIFORM_BUFFER, 1, lsmUBO));
+//		GLCall(glBindBuffer(GL_UNIFORM_BUFFER, 0));
+	}
 } // namespace lei3d

--- a/src/engine/components/Lights.hpp
+++ b/src/engine/components/Lights.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "glm/glm.hpp"
+#include <vector>
 
 namespace lei3d
 {
@@ -8,14 +9,15 @@ namespace lei3d
 	class DirectionalLight
 	{
 	public:
-		DirectionalLight(glm::vec3 dir = glm::vec3{ 0, -1, 0 }, glm::vec3 col = glm::vec3{ 1.f }, float intensity = 1.f)
-			: direction(glm::normalize(dir)), color(col), intensity(intensity) {}
+		DirectionalLight(glm::vec3 dir = glm::vec3{ 0, -1, 0 }, glm::vec3 col = glm::vec3{ 1.f }, float intensity = 1.f);
 
 		glm::vec3 direction;
 		glm::vec3 color;
-		float	  intensity;
+		float intensity;
 
-		float nearPlane, farPlane;
+		std::vector<float> cascadeLevels;
+		std::vector<glm::mat4> lightSpaceMatrices;
+//		unsigned int lsmUBO;
 	};
 
 } // namespace lei3d

--- a/src/engine/core/Application.cpp
+++ b/src/engine/core/Application.cpp
@@ -66,8 +66,8 @@ namespace lei3d
 	{
 		// GLFW INITIALIZE --------------------------------
 		glfwInit();
-		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
 		glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
 #ifdef __APPLE__

--- a/src/engine/core/Camera.cpp
+++ b/src/engine/core/Camera.cpp
@@ -112,6 +112,16 @@ namespace lei3d
 		return m_Pitch;
 	}
 
+	float Camera::GetNearPlane() const
+	{
+		return m_NearPlane;
+	}
+
+	float Camera::GetFarPlane() const
+	{
+		return m_FarPlane;
+	}
+
 	void Camera::SetFOV(float fovDeg)
 	{
 		m_FOVDeg = fovDeg;

--- a/src/engine/core/Camera.hpp
+++ b/src/engine/core/Camera.hpp
@@ -51,9 +51,12 @@ namespace lei3d
 		glm::vec3 GetPosition() const;
 		glm::vec3 GetFront() const;
 		glm::vec3 GetUp() const;
-		float	  GetFOV() const;
-		float	  GetYaw() const;
-		float	  GetPitch() const;
+		float GetFOV() const;
+		float GetYaw() const;
+		float GetPitch() const;
+
+		float GetNearPlane() const;
+		float GetFarPlane() const;
 
 		virtual void OnImGuiRender() {}
 		virtual void cameraMouseCallback(double xPosInput, double yPosInput);

--- a/src/engine/rendering/RenderSystem.cpp
+++ b/src/engine/rendering/RenderSystem.cpp
@@ -4,6 +4,7 @@
 #include "components/SkyBox.hpp"
 #include "logging/GLDebug.hpp"
 
+#include "glm/gtc/type_ptr.hpp"
 #include <array>
 
 namespace lei3d
@@ -16,7 +17,7 @@ namespace lei3d
 
 		forwardShader = Shader("./data/shaders/forward.vert", "./data/shaders/forward.frag");
 		postprocessShader = Shader("./data/shaders/screenspace_quad.vert", "./data/shaders/postprocess.frag");
-		shadowCSMShader = Shader("./data/shaders/shadow_depth.vert", "./data/shaders/null.frag");
+		shadowCSMShader = Shader("./data/shaders/shadow_depth.vert", "./data/shaders/null.frag", "./data/shaders/depth_cascades.geom");
 
 		glGenVertexArrays(1, &dummyVAO);
 
@@ -64,19 +65,24 @@ namespace lei3d
 
 		glGenFramebuffers(1, &shadowFBO);
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, shadowFBO);
-
 		glGenTextures(1, &shadowDepth);
 
-		// depth map; unused
-		glBindTexture(GL_TEXTURE_2D, shadowDepth);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32F, shadowResolution, shadowResolution, 0, GL_DEPTH_COMPONENT,
-			GL_FLOAT, nullptr);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, shadowDepth, 0);
+		// depth map
+		glBindTexture(GL_TEXTURE_2D_ARRAY, shadowDepth);
+		glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_DEPTH_COMPONENT32F, shadowResolution, shadowResolution, 4, 0, GL_DEPTH_COMPONENT,
+			GL_FLOAT, nullptr); ///< should always be 4 levels
+		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, shadowDepth, 0);
 
+		glDrawBuffer(GL_NONE);
+		glReadBuffer(GL_NONE);
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-		///< error checks
+
+//		unsigned int lightMatsIdx = glGetUniformBlockIndex(shadowCSMShader.getShaderID(), "LightSpaceMatrices");
+//		glUniformBlockBinding(shadowCSMShader.getShaderID(), lightMatsIdx, 1);
+//		lightMatsIdx = glGetUniformBlockIndex(forwardShader.getShaderID(), "LightSpaceMatrices");
+//		glUniformBlockBinding(forwardShader.getShaderID(), lightMatsIdx, 1);
 	}
 
 	void RenderSystem::draw(const Scene& scene, const SceneView& view)
@@ -88,8 +94,8 @@ namespace lei3d
 		glClearColor(0.2f, 0.8f, 0.9f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
 
-		Camera&						camera = view.ActiveCamera(scene);
-		SkyBox*						skyBox = nullptr;
+		Camera& camera = view.ActiveCamera(scene);
+		SkyBox* skyBox = nullptr;
 		std::vector<ModelInstance*> modelEntities;
 		for (auto& entity : scene.m_Entities)
 		{
@@ -136,11 +142,21 @@ namespace lei3d
 		forwardShader.setVec3("dirLight.direction", light->direction);
 		forwardShader.setVec3("dirLight.color", light->color);
 		forwardShader.setFloat("dirLight.intensity", light->intensity);
-		forwardShader.setUniformMat4("lightSpaceMatrix", lightSpaceMat);
+		forwardShader.setFloat("dirLight.farPlane", camera.GetFarPlane());
+		for (int i = 0; i < light->cascadeLevels.size(); i++)
+		{
+			forwardShader.setFloat(("dirLight.cascadeDistances[" + std::to_string(i) + "]"), light->cascadeLevels[i]);
+		}
+//		glBindBufferBase(GL_UNIFORM_BUFFER, 1, light->lsmUBO);
+
+		for (int i = 0; i < light->lightSpaceMatrices.size(); i++)
+		{
+			forwardShader.setUniformMat4(("lightSpaceMatrices[" + std::to_string(i) + "]"), light->lightSpaceMatrices[i]);
+		}
 
 		forwardShader.setInt("shadowDepth", 1);
 		glActiveTexture(GL_TEXTURE1);
-		glBindTexture(GL_TEXTURE_2D, shadowDepth);
+		glBindTexture(GL_TEXTURE_2D_ARRAY, shadowDepth);
 
 		for (auto& obj : objects)
 		{
@@ -182,9 +198,9 @@ namespace lei3d
 
 		// draw a full screen quad, sample from rendered textures
 		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, rawTexture); // 0
+		glBindTexture(GL_TEXTURE_2D, rawTexture);	   // 0
 		glActiveTexture(GL_TEXTURE1);
-		glBindTexture(GL_TEXTURE_2D, saturationMask); // 1
+		glBindTexture(GL_TEXTURE_2D, saturationMask);  // 1
 		postprocessShader.setInt("RawFinalImage", 0);
 		postprocessShader.setInt("SaturationMask", 1); // match active texture bindings
 
@@ -205,17 +221,25 @@ namespace lei3d
 		shadowCSMShader.bind();
 
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, shadowFBO);
-		glDrawBuffer(GL_COLOR_ATTACHMENT0);
 
 		glViewport(0, 0, shadowResolution, shadowResolution);
 		glCullFace(GL_FRONT);
 		glDepthMask(GL_TRUE);
 		glEnable(GL_DEPTH_TEST); // enable drawing to depth mask and depth testing
-		glClearColor(0.f, 0.f, 0.f, 1.0f);
-		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+		glClear(GL_DEPTH_BUFFER_BIT);
 
-		lightSpaceMat = getLightSpaceMatrix(light, 0.1f, 500.f, camera);	// TODO: set it to camera planes?
-		shadowCSMShader.setUniformMat4("lightSpaceMatrix", lightSpaceMat);
+		light->lightSpaceMatrices = getLightSpaceMatrices(light, camera);
+		for (int i = 0; i < light->lightSpaceMatrices.size(); i++)
+		{
+			shadowCSMShader.setUniformMat4(("lightSpaceMatrices[" + std::to_string(i) + "]"), light->lightSpaceMatrices[i]);
+		}
+		// TODO: figure out why UBOs not working later
+	//		glBindBuffer(GL_UNIFORM_BUFFER, light->lsmUBO);
+	//		for (int i = 0; i < light->lightSpaceMatrices.size(); i++) {
+	//			printf("%llu %llu\n", i * sizeof(glm::mat4x4), sizeof(glm::mat4x4));
+	//			GLCall(glBufferSubData(GL_UNIFORM_BUFFER, i * sizeof(glm::mat4x4), sizeof(glm::mat4x4), glm::value_ptr(light->lightSpaceMatrices[i])));
+	//		}
+	//		glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
 		for (auto& obj : objects)
 		{
@@ -246,7 +270,7 @@ namespace lei3d
 
 	glm::mat4 RenderSystem::getLightSpaceMatrix(DirectionalLight* light, float nearPlane, float farPlane, Camera& camera)
 	{
-		const glm::mat4	projection = glm::perspective(glm::radians(camera.GetFOV()), (float)scwidth / (float)scheight, nearPlane, farPlane);
+		const glm::mat4 projection = glm::perspective(glm::radians(camera.GetFOV()), (float)scwidth / (float)scheight, nearPlane, farPlane);
 		const std::vector<glm::vec4> corners = getFrustumCornersWS(projection, camera.GetView());
 
 		glm::vec3 center = glm::vec3(0.f);
@@ -274,7 +298,6 @@ namespace lei3d
 			pmaxZ = std::max(pmaxZ, trf.z);
 		}
 
-		float frustum_fitting_factor = 1.f;
 		if (pminZ < 0)
 		{
 			pminZ *= frustum_fitting_factor;
@@ -292,10 +315,30 @@ namespace lei3d
 			pmaxZ *= frustum_fitting_factor;
 		}
 
-		light->nearPlane = pminZ;
-		light->farPlane = pmaxZ;
 		const glm::mat4 lightProj = glm::ortho(pminX, pmaxX, pminY, pmaxY, pminZ, pmaxZ);
 		return lightProj * lightView;
+	}
+
+	std::vector<glm::mat4> RenderSystem::getLightSpaceMatrices(DirectionalLight* light, Camera& camera)
+	{
+		std::vector<glm::mat4> matrices;
+		matrices.reserve(light->cascadeLevels.size() + 1);
+		for (int i = 0; i < light->cascadeLevels.size() + 1; i++)
+		{
+			if (i == 0)
+			{
+				matrices.push_back(getLightSpaceMatrix(light, camera.GetNearPlane(), light->cascadeLevels[i], camera));
+			}
+			else if (i < light->cascadeLevels.size())
+			{
+				matrices.push_back(getLightSpaceMatrix(light, light->cascadeLevels[i - 1], light->cascadeLevels[i], camera));
+			}
+			else
+			{
+				matrices.push_back(getLightSpaceMatrix(light, light->cascadeLevels[i - 1], camera.GetFarPlane(), camera));
+			}
+		}
+		return matrices;
 	}
 
 } // namespace lei3d

--- a/src/engine/rendering/RenderSystem.hpp
+++ b/src/engine/rendering/RenderSystem.hpp
@@ -39,6 +39,7 @@ namespace lei3d
 		void genShadowPass(const std::vector<ModelInstance*>& objects, DirectionalLight* light, Camera& camera);
 		std::vector<glm::vec4> getFrustumCornersWS(const glm::mat4& projection, const glm::mat4& view);
 		glm::mat4 getLightSpaceMatrix(DirectionalLight* light, float nearPlane, float farPlane, Camera& camera);
+		std::vector<glm::mat4> getLightSpaceMatrices(DirectionalLight* light, Camera& camera);
 
 		// offscreen render target objects
 		unsigned int FBO;
@@ -49,13 +50,13 @@ namespace lei3d
 
 		// shadow resources
 		unsigned int shadowFBO;
-		glm::mat4 lightSpaceMat;
 		unsigned int shadowResolution = 2048;
 		unsigned int shadowDepth;
 
 		unsigned int dummyVAO; // used to draw full-screen "quad"
 
 		int scwidth, scheight;
+		float frustum_fitting_factor = 10.f;	// TODO: make configurable through scenes?
 
 		// shaders
 		Shader forwardShader;

--- a/src/engine/rendering/RenderSystem.hpp
+++ b/src/engine/rendering/RenderSystem.hpp
@@ -51,7 +51,6 @@ namespace lei3d
 		unsigned int shadowFBO;
 		glm::mat4 lightSpaceMat;
 		unsigned int shadowResolution = 2048;
-		unsigned int shadowMoments;
 		unsigned int shadowDepth;
 
 		unsigned int dummyVAO; // used to draw full-screen "quad"
@@ -61,7 +60,7 @@ namespace lei3d
 		// shaders
 		Shader forwardShader;
 		Shader postprocessShader;
-		Shader shadowEVSMShader;
+		Shader shadowCSMShader;
 	};
 
 } // namespace lei3d

--- a/src/engine/rendering/Shader.hpp
+++ b/src/engine/rendering/Shader.hpp
@@ -22,7 +22,7 @@ namespace lei3d
 
 	public:
 		Shader();
-		Shader(const char* vertexShaderPath, const char* fragShaderPath);
+		Shader(const char* vertexShaderPath, const char* fragShaderPath, const char* geomShaderPath = nullptr);
 
 		// compile and link shader, then activate the shader
 		void bind() const;
@@ -35,6 +35,8 @@ namespace lei3d
 		void setVec2(const std::string& name, const glm::vec2& value) const;
 		void setVec3(const std::string& name, const glm::vec3& value) const;
 		void setUniformMat4(const std::string& name, const glm::mat4& matrix) const;
+
+		unsigned int getShaderID() const { return m_ShaderID; }
 
 	private:
 		int getUniformLocation(const std::string& name) const;


### PR DESCRIPTION
Shadows should look crisper at close up

Also added shader support for geometry shaders, needed for CSM  
Originally wanted to use uniform buffer objects (UBO) for matrix data, but was breaking for some reason. Will investigate later, especially for performance reasons.